### PR TITLE
Fix windows compatibility

### DIFF
--- a/engine/Shopware/Components/Snippet/DatabaseHandler.php
+++ b/engine/Shopware/Components/Snippet/DatabaseHandler.php
@@ -117,6 +117,7 @@ class DatabaseHandler
             $filePath = $file->getRelativePathname();
             if (strpos($filePath, '.ini') == strlen($filePath) - 4) {
                 $namespace = substr($filePath, 0, -4);
+                $namespace = str_replace('\\', '/', $namespace);
             } else {
                 continue;
             }
@@ -246,6 +247,7 @@ class DatabaseHandler
             $filePath = $file->getRelativePathname();
             if (strpos($filePath, '.ini') == strlen($filePath) - 4) {
                 $namespace = substr($filePath, 0, -4);
+                $namespace = str_replace('\\', '/', $namespace);
             } else {
                 continue;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
To fix windows compatibilty (yes, one can develop on windows).

Since windows directory separators are a backslashes, the namespace was also with backslashes which breaks all snippets.

Even if windows is not officially supported this should be fixed, which is exactly what this commit does.

### 2. What does this change do, exactly?
Replace backslashes in generated snippets namespaces with forward slashes.

### 3. Describe each step to reproduce the issue or behaviour.
Tried to install Shopware on windows (via composer, some more fixes are needed for that, which i'm working on, e.g. no bash files but using the symfony console and filesystem components for the composer events)

### 4. Please link to the relevant issues (if any).
not applicable

### 5. Which documentation changes (if any) need to be made because of this PR?
not applicable

### 6. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.